### PR TITLE
Update to v0.14.16.0

### DIFF
--- a/org.firo.firo-qt.json
+++ b/org.firo.firo-qt.json
@@ -32,8 +32,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/firoorg/firo/releases/download/v0.14.15.3/firo-0.14.15.3-linux64.tar.gz",
-                    "sha256": "df6d0fb6abc8998909ecb3c3f4c5aa0b6bbf00474bb4739349d12079874754fc",
+                    "url": "https://github.com/firoorg/firo/releases/download/v0.14.16.0/firo-0.14.16.0-linux64.tar.gz",
+                    "sha256": "b8f6ff5d7481e5a9dd7c5ad71caa62658b7747a8f3512999786229458397c59d",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://github.com/firoorg/firo/releases.atom",

--- a/org.firo.firo-qt.metainfo.xml
+++ b/org.firo.firo-qt.metainfo.xml
@@ -29,7 +29,7 @@
   <screenshots>
     <screenshot type="default">
       <image type="source">
-        https://raw.githubusercontent.com/firoorg/firo/0f9d27dfef6f27f5c4d97a060c0954846d3ea547/contrib/debian/qt-screenshot.jpg
+        https://raw.githubusercontent.com/firoorg/firo/837983954d1bc5b1e70474b14b1376747f42c692/contrib/debian/qt-screenshot.png
       </image>
     </screenshot>
   </screenshots>

--- a/org.firo.firo-qt.metainfo.xml
+++ b/org.firo.firo-qt.metainfo.xml
@@ -34,6 +34,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release date="2026-05-15" version="0.14.16.0"/>
     <release date="2026-03-10" version="0.14.15.3"/>
     <release date="2026-01-22" version="0.14.15.2"/>
     <release date="2026-01-08" version="0.14.15.1"/>


### PR DESCRIPTION
This is a mandatory update with a hard fork date of approximately 22 June 2026 (block 1,329,000)

https://github.com/firoorg/firo/releases/tag/v0.14.16.0